### PR TITLE
Update git submodule path to allow fetching via SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Collabjam-Shared-Types"]
 	path = src/shared
-	url = https://github.com/TactileVision/CollabJam-Shared
+	url = ../CollabJam-Shared


### PR DESCRIPTION
Previously the url of the submodule was an absolute path using HTTP authentication. This leads to issues when user authenticate against Github using an SSH key.

With this change we now use a relative path to the submodule. This allows both authentication methods (either HTTP or SSH).