### PR TITLE
fix(editor): update block selection color in TactonGraph

### DIFF
--- a/src/renderer/components/TactonGraph.vue
+++ b/src/renderer/components/TactonGraph.vue
@@ -652,13 +652,13 @@ export default defineComponent({
                 blockContainer.removeChild(oldControls);
                 oldControls.destroy({ children: true });
               }
-              // const newControls = this.drawBlockControls(
-              //   i,
-              //   currentIndex,
-              //   blockContainer.width,
-              //   blockContainer,
-              //   true,
-              // );
+              this.drawBlockControls(
+                i,
+                currentIndex,
+                blockContainer.width,
+                blockContainer,
+                true,
+              );
               this.selectedBlock = {
                 moving: true,
                 channel: i,
@@ -931,11 +931,12 @@ export default defineComponent({
 
       const blockControls = new PIXI.Container();
 
-      const lineWidth = highlighted ? 4 : 2;
+      const color = highlighted ? 0xec660c : 0x6c6c60;
+      const lineWidth = 2;
       const rect = new PIXI.Graphics();
       rect.setStrokeStyle({
         width: lineWidth,
-        color: 0xec660c,
+        color,
         matrix: new PIXI.Matrix(),
       });
       // rect.lineStyle(lineWidth, 0xec660c);
@@ -951,7 +952,7 @@ export default defineComponent({
         // border.lineStyle(2, 0xec660c);
         border.setStrokeStyle({
           width: 2,
-          color: 0xec660c,
+          color,
           matrix: new PIXI.Matrix(),
         });
         //border.lineStyle(2, 0x0000000);


### PR DESCRIPTION
This changes the selection behavior of blocks in the TactonGraph component. By default all blocks will be rendered without a border. When selected an orange border will be painted around the blocks to indicate that they are selected.

[Screencast from 2024-05-25 12-55-40.webm](https://github.com/TactileVision/CollabJam-Client/assets/61323346/d22e53d0-897b-4e0c-b6a7-e3f65e86c52c)

Fixes #34