### PR TITLE
feat: show actuation indicator while jamming

### DIFF
--- a/src/renderer/components/TactonGraph.vue
+++ b/src/renderer/components/TactonGraph.vue
@@ -139,6 +139,9 @@ export default defineComponent({
     playbackTime(): number {
       return this.store.state.tactonPlayback.playbackTime;
     },
+    channelStates(): OutputChannelState[] {
+      return [...this.store.state.tactonSettings.outputChannelState];
+    }
   },
   watch: {
     //start to drawing if all components are mounted
@@ -190,6 +193,18 @@ export default defineComponent({
       // this.cursor.moveToPosition(time * this.growRatio + this.paddingRL)
       this.positionCursor(time);
     },
+    channelStates() {
+      const coordinateContainer = this.coordinateContainer;
+      if(!coordinateContainer) return;
+
+      this.channelStates.forEach(state => {
+        const graphics = coordinateContainer.getChildByLabel(`actuation-indicator-${state.channelId}`) as PIXI.Graphics | null;
+        if(graphics) {
+          const color = state.intensity > 0 ? state.author?.color || 0xec660c : 0x6c6c60;
+          graphics.tint = color;
+        }
+      })
+    }
   },
   async mounted() {
     try {
@@ -360,6 +375,15 @@ export default defineComponent({
         yPosition += distLinesY;
         graphics.moveTo(this.paddingRL, yPosition);
         graphics.lineTo(this.width.actual - this.paddingRL, yPosition).stroke();
+
+        if(i < this.numberOfOutputs) {
+          const actuationIndicator = new PIXI.Graphics();
+          actuationIndicator.circle(this.paddingRL / 2, yPosition, (this.paddingRL * 0.4) / 2);
+          actuationIndicator.tint = 0x6c6c60;
+          actuationIndicator.fill({ color: 0xffffff, matrix: new PIXI.Matrix(), alpha: 1 });
+          actuationIndicator.label = `actuation-indicator-${i}`;
+          this.coordinateContainer?.addChild(actuationIndicator);
+        }
       }
 
       //draw vertil lines and labels

--- a/src/renderer/components/TactonGraphWrapper.vue
+++ b/src/renderer/components/TactonGraphWrapper.vue
@@ -1,11 +1,4 @@
 <template>
-  <v-row
-    no-gutters
-    align="center"
-    style="justify-content: space-evenly; margin: 5px 0"
-    id="tactonHeader"
-  >
-  </v-row>
   <TactonGraph :is-mounted="isMounted" />
 </template>
 
@@ -13,10 +6,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useStore } from "@/renderer/store/store";
-import { WebSocketAPI } from "@/main/WebSocketManager";
 import TactonGraph from "./TactonGraph.vue";
-import { InteractionMode } from "@sharedTypes/roomTypes";
 
 export default defineComponent({
   name: "TactonGraphWrapper",
@@ -25,38 +15,6 @@ export default defineComponent({
     isMounted: {
       type: Boolean,
     },
-  },
-  data() {
-    return {
-      store: useStore(),
-    };
-  },
-  computed: {
-    maxDurationStore(): number {
-      return this.store.state.roomSettings.maxDuration;
-    },
-    duration: {
-      get(): string {
-        return (this.maxDurationStore / 1000).toString() + "s";
-      },
-      set(newValue: string) {
-        WebSocketAPI.updateTactonDuration({
-          roomId: this.store.state.roomSettings.id || "",
-          duration: parseInt(newValue.substring(0, newValue.length - 1)) * 1000,
-        });
-      },
-    },
-    mode(): InteractionMode {
-      return this.store.state.roomSettings.mode;
-    },
-  },
-  methods: {
-    // saveTacton() {
-    //   sendSocketMessage(WS_MSG_TYPE.GET_TACTON_SERV, {
-    //     roomId: this.store.state.roomSettings.id,
-    //     shouldRecord: false,
-    //   });
-    // },
   },
 });
 </script>


### PR DESCRIPTION
some limitations:
- This currently only works while jamming (during playback we do not record the channel states yet).
- The indicators are quite pixelated. I decided to put them in the PIXI canvas to ensure that they have the perfect positioning, but the canvas has antialiasing disabled which is why the circles appear pixelated. 

[Screencast from 2024-05-29 14-25-16.webm](https://github.com/TactileVision/CollabJam-Client/assets/61323346/3c12b7af-a51e-4619-b84c-45f23bad4f98)

fixes #39