### PR TITLE
fix: do not ignore the first button press on a new gamepad

### DIFF
--- a/src/renderer/store/modules/collaboration/playGround/playGround.ts
+++ b/src/renderer/store/modules/collaboration/playGround/playGround.ts
@@ -256,6 +256,9 @@ export const actions: ActionTree<State, RootState> & Actions = {
 
     const binding = payload.profile.bindings[index];
 
+    // Prevent deactivate if the binding was never activated
+    if (binding.activeTriggers <= 0) return;
+
     const store = useStore();
     const newBinding = {
       ...binding,


### PR DESCRIPTION
Previously when first registering a gamepad, the button press would not be imediately detected and you could not use this button anymore afterwards.

The reason for this is that the gamepad had no predefined profile. The profile gets created once the device registration registers the new device (the scanning code is in `CollaborationBody.vue`). However, the registration might happen one frame later than the first input event is registered.

When releasing the button the profile is created and the `activeTriggers` value of the binding gets decremented to -1. Afterwards, the binding cannot be activated anymore. This could be fixed by adding a guard in `deactivateKey` to return early if `activeTriggers` is less than or equal to zero.

However, this means that the first button press will not be registered by the system. To fix this, profile creation now might also happen when registering an input event.

fixes #51