### PR TITLE
fix: prevent block size to be less than 50 ms when editing

### DIFF
--- a/src/renderer/components/TactonGraph.vue
+++ b/src/renderer/components/TactonGraph.vue
@@ -1197,8 +1197,8 @@ export default defineComponent({
             return true;
           }
           // Check if new length is negative
-          if (length < 0) {
-            newWidth = 1;
+          if (length < 50) {
+            newWidth = 50 * this.growRatio;
             if (direction === StretchDirection.NEGATIVE) {
               newX = container.x + instructionsContainer.width - newWidth;
             }


### PR DESCRIPTION
I made this a fixed min width of 50ms. Is this fine?

[Screencast from 2024-06-05 15-54-16.webm](https://github.com/TactileVision/CollabJam-Client/assets/61323346/9482d63f-089e-4ea8-b470-fbad4e7993bd)


fixes #53