### PR TITLE
fix: do not accept keyboard events when typing in an input

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -89,6 +89,8 @@ export default defineComponent({
       if (e.repeat) return;
       if (this.store.state.playGround.inEditMode) return;
       if (!this.correctFrameForInput()) return;
+      if (document.activeElement?.tagName === 'INPUT') return;
+
       const input: KeyInput = {
         type: UserInputType.Key,
         key: e.key.toUpperCase(),
@@ -109,6 +111,8 @@ export default defineComponent({
     buttonUp(e: KeyboardEvent) {
       if (this.store.state.playGround.inEditMode) return;
       if (!this.correctFrameForInput()) return;
+      if (document.activeElement?.tagName === 'INPUT') return;
+
       const input: KeyInput = {
         type: UserInputType.Key,
         key: e.key.toUpperCase(),


### PR DESCRIPTION
There might be a better way to check if the user is typing into an input field but for now this should be good enough.

fixes #50