### PR TITLE
Merge fix for issues #80 invisible block on first recording

### DIFF
--- a/src/renderer/components/CollaborationHeader.vue
+++ b/src/renderer/components/CollaborationHeader.vue
@@ -14,7 +14,8 @@
                 @mouseenter="showToolTip(toolTipKeys.RECORD)"
                 @mouseleave="clearToolTip"
                 :disabled="
-                  store.state.roomSettings.mode == 3
+                  store.state.roomSettings.mode == 3 ||
+                  store.state.roomSettings.id === undefined
                 "
                 :icon="
                   store.state.roomSettings.mode == 2 ? 'mdi-stop' : 'mdi-record'

--- a/src/renderer/components/TheTimeline.vue
+++ b/src/renderer/components/TheTimeline.vue
@@ -118,6 +118,26 @@ export default defineComponent({
       const viewportWidth = this.store.state.timeline.canvasWidth - config.leftPadding;
       return viewportWidth / durationInPixels;
     },
+    initTimelineState(): void {
+      // init timeline
+      const durationInPixels = this.durationToPixels(config.baseTrackDurationMs);
+      const zoom = this.calculateInitialZoom(durationInPixels);
+
+      this.store.dispatch(
+        TimelineActionTypes.UPDATE_HORIZONTAL_VIEWPORT_OFFSET,
+        0,
+      );
+      this.store.dispatch(
+        TimelineActionTypes.UPDATE_INITIAL_VIRTUAL_VIEWPORT_WIDTH,
+        durationInPixels,
+      );
+      this.store.dispatch(
+        TimelineActionTypes.UPDATE_CURRENT_VIRTUAL_VIEWPORT_WIDTH,
+        durationInPixels,
+      );
+      this.store.dispatch(TimelineActionTypes.UPDATE_ZOOM_LEVEL, zoom);
+      this.store.dispatch(TimelineActionTypes.UPDATE_INITIAL_ZOOM_LEVEL, zoom);
+    },
     playback() {
       const x = ((this.currentTime / 1000) * (config.pixelsPerSecond * this.store.state.timeline.zoomLevel));
       this.playHead?.moveToPosition(x, this.isSliderFollowing);
@@ -317,25 +337,7 @@ export default defineComponent({
         this.store.state.timeline.blockManager?.clearData();
         this.store.state.timeline.groups.clear();
         this.store.dispatch(TimelineActionTypes.DELETE_ALL_BLOCKS);
-        
-        // init timeline
-        const durationInPixels = this.durationToPixels(config.baseTrackDurationMs);
-        const zoom = this.calculateInitialZoom(durationInPixels);
-
-        this.store.dispatch(
-            TimelineActionTypes.UPDATE_HORIZONTAL_VIEWPORT_OFFSET,
-            0,
-        );
-        this.store.dispatch(
-            TimelineActionTypes.UPDATE_INITIAL_VIRTUAL_VIEWPORT_WIDTH,
-            durationInPixels,
-        );
-        this.store.dispatch(
-            TimelineActionTypes.UPDATE_CURRENT_VIRTUAL_VIEWPORT_WIDTH,
-            durationInPixels,
-        );
-        this.store.dispatch(TimelineActionTypes.UPDATE_ZOOM_LEVEL, zoom);
-        this.store.dispatch(TimelineActionTypes.UPDATE_INITIAL_ZOOM_LEVEL, zoom);
+        this.initTimelineState();
       }
     },
     interactionMode(mode) {
@@ -364,23 +366,7 @@ export default defineComponent({
         this.sliderStateSnapshot.viewportWidth = this.store.state.timeline.currentVirtualViewportWidth;
         
         // calculate full timeline zoom
-        const durationInPixels = this.durationToPixels(config.baseTrackDurationMs);
-        const zoom = this.calculateInitialZoom(durationInPixels);
-
-        this.store.dispatch(
-            TimelineActionTypes.UPDATE_HORIZONTAL_VIEWPORT_OFFSET,
-            0,
-        );
-        this.store.dispatch(
-            TimelineActionTypes.UPDATE_INITIAL_VIRTUAL_VIEWPORT_WIDTH,
-            durationInPixels,
-        );
-        this.store.dispatch(
-            TimelineActionTypes.UPDATE_CURRENT_VIRTUAL_VIEWPORT_WIDTH,
-            durationInPixels,
-        );
-        this.store.dispatch(TimelineActionTypes.UPDATE_ZOOM_LEVEL, zoom);
-        this.store.dispatch(TimelineActionTypes.UPDATE_INITIAL_ZOOM_LEVEL, zoom);
+        this.initTimelineState();
 
         // prepare for recording
         this.slider.setInteractivity(false);
@@ -522,6 +508,8 @@ export default defineComponent({
     this.ticker = PIXI.Ticker.shared;
     this.ticker.autoStart = false;
     this.ticker.stop();
+
+    this.initTimelineState();
     
     // instantiateArray to initialize computed-value channelStates
     this.store.dispatch(TactonSettingsActionTypes.instantiateArray);

--- a/src/renderer/components/TheTimeline.vue
+++ b/src/renderer/components/TheTimeline.vue
@@ -276,9 +276,6 @@ export default defineComponent({
 
           this.playHead?.drawCursor();
           this.playHead?.hide();
-
-          // render components
-          this.mounted = true;
         } else {
           // current tacton was updated
           // parse instructions
@@ -316,9 +313,29 @@ export default defineComponent({
           //this.renderTrackLines();
         }
       } else {
+        // clear data
         this.store.state.timeline.blockManager?.clearData();
         this.store.state.timeline.groups.clear();
         this.store.dispatch(TimelineActionTypes.DELETE_ALL_BLOCKS);
+        
+        // init timeline
+        const durationInPixels = this.durationToPixels(config.baseTrackDurationMs);
+        const zoom = this.calculateInitialZoom(durationInPixels);
+
+        this.store.dispatch(
+            TimelineActionTypes.UPDATE_HORIZONTAL_VIEWPORT_OFFSET,
+            0,
+        );
+        this.store.dispatch(
+            TimelineActionTypes.UPDATE_INITIAL_VIRTUAL_VIEWPORT_WIDTH,
+            durationInPixels,
+        );
+        this.store.dispatch(
+            TimelineActionTypes.UPDATE_CURRENT_VIRTUAL_VIEWPORT_WIDTH,
+            durationInPixels,
+        );
+        this.store.dispatch(TimelineActionTypes.UPDATE_ZOOM_LEVEL, zoom);
+        this.store.dispatch(TimelineActionTypes.UPDATE_INITIAL_ZOOM_LEVEL, zoom);
       }
     },
     interactionMode(mode) {
@@ -508,6 +525,7 @@ export default defineComponent({
     
     // instantiateArray to initialize computed-value channelStates
     this.store.dispatch(TactonSettingsActionTypes.instantiateArray);
+    this.mounted = true;
   },
   beforeUnmount() {
     WebSocketAPI.requestEditingForUuids(


### PR DESCRIPTION
Fixed faulty timeline behaviour as described in issue #80.

- show timeline after pixi app is created
- disable recording button if the user has not joined a room yet
- closes #80 