### PR TITLE
Merge fix for issue #68 laggy timeline when resizing

### DIFF
--- a/src/renderer/helpers/timeline/pixiApp.ts
+++ b/src/renderer/helpers/timeline/pixiApp.ts
@@ -11,7 +11,7 @@ let liveContainer: Container;
 let lockContainer: Container;
 let resizeObserver: ResizeObserver;
 let line: Graphics;
-
+let store: Store;
 /**
  * Initialises the Pixi-Canvas
  */
@@ -29,7 +29,7 @@ export async function createPixiApp(): Promise<void> {
     antialias: true,
   });
 
-  const store: Store = useStore();
+  store = useStore();
 
   const wrapper: HTMLElement | null = document.getElementById("timelineCanvas");
   if (wrapper == null) {
@@ -43,7 +43,7 @@ export async function createPixiApp(): Promise<void> {
   // create canvas
   pixiApp.renderer.resize(wrapper.clientWidth, height);
   pixiApp.canvas.style.position = "absolute";
-  pixiApp.canvas.style.right = "0";
+  pixiApp.canvas.style.left = "0";
   pixiApp.canvas.style.top = "0";
 
   // add canvas to wrapper
@@ -79,7 +79,9 @@ export async function createPixiApp(): Promise<void> {
 
   const resizeCallback = (): void => {
     if (pixiApp == undefined) return;
-    if (pixiApp.renderer.width === wrapper.clientWidth) return;
+    const currentWidth: number = pixiApp.renderer.width;
+    const newWidth: number = wrapper.clientWidth;
+    if (currentWidth === newWidth) return;
 
     const boundingRect: DOMRect = wrapper.getBoundingClientRect();
     store.dispatch(TimelineActionTypes.UPDATE_WRAPPER_X_OFFSET, boundingRect.x);
@@ -87,20 +89,10 @@ export async function createPixiApp(): Promise<void> {
       TimelineActionTypes.UPDATE_WRAPPER_Y_OFFSET,
       boundingRect.top,
     );
-    store.dispatch(
-      TimelineActionTypes.UPDATE_CANVAS_WIDTH,
-      wrapper.clientWidth,
-    );
-
-    const newWidth: number = wrapper.clientWidth;
-    const currentWidth: number = pixiApp.renderer.width;
-
-    if (currentWidth !== newWidth) {
-      animateResize(currentWidth, newWidth, height, 250);
-    }
+    animateResize(currentWidth, newWidth, height, 150);
   };
 
-  resizeObserver = new ResizeObserver(debounce(resizeCallback, 200));
+  resizeObserver = new ResizeObserver(debounce(resizeCallback, 100));
   resizeObserver.observe(wrapper);
 
   const boundingRect: DOMRect = wrapper.getBoundingClientRect();
@@ -115,9 +107,9 @@ function debounce<T extends (...args: unknown[]) => void>(
 ): (...args: Parameters<T>) => void {
   let timeoutId: ReturnType<typeof setTimeout>;
 
-  return (...args: Parameters<T>) => {
+  return (...args: Parameters<T>): void => {
     clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => func(...args), delayMs);
+    timeoutId = setTimeout((): void => func(...args), delayMs);
   };
 }
 
@@ -130,19 +122,17 @@ function animateResize(
   to: number,
   height: number,
   duration: number,
-) {
-  const start = performance.now();
-
-  function frame(now: number) {
-    const progress = Math.min((now - start) / duration, 1);
-
-    // Ease-Out
-    const eased = 1 - Math.pow(1 - progress, 3);
-
-    const currentWidth = from + (to - from) * eased;
+): void {
+  const start: number = performance.now();
+  function frame(now: number): void {
+    const progress: number = Math.min((now - start) / duration, 1);
+    const eased: number = 1 - Math.pow(1 - progress, 6);
+    const currentWidth: number = from + (to - from) * eased;
 
     pixiApp.renderer.resize(currentWidth, height);
     pixiApp.render();
+    // TODO could be even smoother if this is set before -> grid lines are already rendered but need to split slider update
+    store.dispatch(TimelineActionTypes.UPDATE_CANVAS_WIDTH, currentWidth);
 
     if (progress < 1) {
       requestAnimationFrame(frame);

--- a/src/renderer/helpers/timeline/pixiApp.ts
+++ b/src/renderer/helpers/timeline/pixiApp.ts
@@ -10,7 +10,6 @@ let staticContainer: Container;
 let liveContainer: Container;
 let lockContainer: Container;
 let resizeObserver: ResizeObserver;
-let animationFrameId: number | null = null;
 let line: Graphics;
 
 /**
@@ -77,31 +76,31 @@ export async function createPixiApp(): Promise<void> {
   pixiApp.stage.addChild(liveContainer);
   pixiApp.stage.addChild(lockContainer);
   // TODO if only the height is changed, this observer will not fire, as the wrapper_element hast zero height
-  resizeObserver = new ResizeObserver((): void => {
-    if (pixiApp == undefined) return;
-    if (pixiApp.renderer.width !== wrapper.clientWidth) {
-      if (animationFrameId != null) return;
 
-      animationFrameId = requestAnimationFrame(() => {
-        const boundingRect: DOMRect = wrapper.getBoundingClientRect();
-        store.dispatch(
-          TimelineActionTypes.UPDATE_WRAPPER_X_OFFSET,
-          boundingRect.x,
-        );
-        store.dispatch(
-          TimelineActionTypes.UPDATE_WRAPPER_Y_OFFSET,
-          boundingRect.top,
-        );
-        store.dispatch(
-          TimelineActionTypes.UPDATE_CANVAS_WIDTH,
-          wrapper.clientWidth,
-        );
-        pixiApp.renderer.resize(wrapper.clientWidth, height);
-        pixiApp.render();
-      });
-      animationFrameId = null;
+  const resizeCallback = (): void => {
+    if (pixiApp == undefined) return;
+    if (pixiApp.renderer.width === wrapper.clientWidth) return;
+
+    const boundingRect: DOMRect = wrapper.getBoundingClientRect();
+    store.dispatch(TimelineActionTypes.UPDATE_WRAPPER_X_OFFSET, boundingRect.x);
+    store.dispatch(
+      TimelineActionTypes.UPDATE_WRAPPER_Y_OFFSET,
+      boundingRect.top,
+    );
+    store.dispatch(
+      TimelineActionTypes.UPDATE_CANVAS_WIDTH,
+      wrapper.clientWidth,
+    );
+
+    const newWidth: number = wrapper.clientWidth;
+    const currentWidth: number = pixiApp.renderer.width;
+
+    if (currentWidth !== newWidth) {
+      animateResize(currentWidth, newWidth, height, 250);
     }
-  });
+  };
+
+  resizeObserver = new ResizeObserver(debounce(resizeCallback, 200));
   resizeObserver.observe(wrapper);
 
   const boundingRect: DOMRect = wrapper.getBoundingClientRect();
@@ -109,6 +108,50 @@ export async function createPixiApp(): Promise<void> {
   store.dispatch(TimelineActionTypes.UPDATE_WRAPPER_Y_OFFSET, boundingRect.top);
   store.dispatch(TimelineActionTypes.UPDATE_CANVAS_WIDTH, wrapper.clientWidth);
 }
+
+function debounce<T extends (...args: unknown[]) => void>(
+  func: T,
+  delayMs: number,
+): (...args: Parameters<T>) => void {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  return (...args: Parameters<T>) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func(...args), delayMs);
+  };
+}
+
+/*
+ * Interpolates between two widths.
+ * Currently height is fixed anyway.
+ * */
+function animateResize(
+  from: number,
+  to: number,
+  height: number,
+  duration: number,
+) {
+  const start = performance.now();
+
+  function frame(now: number) {
+    const progress = Math.min((now - start) / duration, 1);
+
+    // Ease-Out
+    const eased = 1 - Math.pow(1 - progress, 3);
+
+    const currentWidth = from + (to - from) * eased;
+
+    pixiApp.renderer.resize(currentWidth, height);
+    pixiApp.render();
+
+    if (progress < 1) {
+      requestAnimationFrame(frame);
+    }
+  }
+
+  requestAnimationFrame(frame);
+}
+
 export function clearPixiApp(): void {
   if (pixiApp == undefined) return;
   pixiApp.destroy({ removeView: true }, { children: true });


### PR DESCRIPTION
Fixed laggy resizing as described in #68.

- Added debouncing (100ms threshold)
- Added interpolation between current and previous width (150ms animation)
- Anchored canvas to the left instead of the right to prevent timeline snapping when shrinking the window
- closes #68 